### PR TITLE
Update IBM-Q REST API

### DIFF
--- a/qcrpc/rest/include/ibmq_json.hpp
+++ b/qcrpc/rest/include/ibmq_json.hpp
@@ -7,9 +7,9 @@ namespace rexrest {
 
 class IBMQJsonParser : JsonParser {
 public:
-    static const std::string kQuasiDists;
-    static const std::string kMetadata;
-    static const std::string kShots;
+    static const std::string kResults;
+    static const std::string kData;
+    static const std::string kSamples;
 
     IBMQJsonParser(const std::string& json_str, std::uint32_t shots) : JsonParser(json_str, shots) {}
     ~IBMQJsonParser() {}

--- a/qcrpc/rest/include/ibmq_rest.hpp
+++ b/qcrpc/rest/include/ibmq_rest.hpp
@@ -25,46 +25,71 @@ private:
 
 enum class IBMQTranspiler : std::uint32_t {
     NONE = 0,
+    NOAI = 1,
+    AI = 2
 };
 
-inline const std::string IBMQTranspilerToString(IBMQTranspiler transpiler) {
-  switch (transpiler) {
-    case IBMQTranspiler::NONE: { return "none"; }
-    default: { return "none"; }
-  }
+inline const std::string IBMQTranspilerUseAI(IBMQTranspiler transpiler) {
+    switch (transpiler) {
+        case IBMQTranspiler::AI: { return "true"; }
+        default: { return "false"; }
+    }
 }
 
 class IBMQHttpClient {
 public:
+    static const std::string kTranspilerServiceURL;
+
+    static const std::string kBackend;
+    static const std::string kHub;
+    static const std::string kGroup;
+    static const std::string kProject;
+
+    static const std::string kTranspilePath;
+    static const std::string kGetTranspilationResultsPath;
     static const std::string kListJobDetailsPath;
     static const std::string kListJobResultsPath;
     static const std::string kRunJobPath;
+
     static const std::string kIDKey;
+    static const std::string kTaskIDKey;
     static const std::string kStatusKey;
+    static const std::string kStateKey;
+    static const std::string kReasonKey;
+    static const std::string kResultKey;
+    static const std::string kQASMKey;
+
     static const std::string kStatusCompletedValue;
     static const std::string kStatusFailedValue;
     static const std::string kStatusCancelledValue;
-    static const std::string kStateKey;
-    static const std::string kReasonKey;
+    static const std::string kStateSuccessValue;
+    static const std::string kStateFailureValue;
 
-    static std::shared_ptr<IBMQHttpClient> CreateHttpClient(const std::string& base_url);
+    static std::shared_ptr<IBMQHttpClient> CreateHttpClient(const std::string& runtime_url);
 
-    IBMQHttpClient(const std::string& base_url) : base_url_(base_url), http_client_(base_url) {}
+    IBMQHttpClient(const std::string& runtime_url) : IBMQHttpClient(runtime_url, kTranspilerServiceURL) {}
+    IBMQHttpClient(const std::string& runtime_url, const std::string& transpile_url) : runtime_url_(runtime_url), transpile_url_(transpile_url),
+        runtime_http_client_(runtime_url), transpile_http_client_(transpile_url) {}
     ~IBMQHttpClient() {}
 
+    std::shared_ptr<JobResult> TranspileCircuit(const std::string& token, const std::string& qasm, const IBMQTranspiler transpiler);
+    std::shared_ptr<JobResult> GetTranspilationResults(const std::string& token, const std::string& task_id);
     std::shared_ptr<JobResult> ListJobDetails(const std::string& path, const std::string& token, const std::string& job_id);
     std::shared_ptr<JobResult> ListJobResults(const std::string& path, const std::string& token, const std::string& job_id);
     std::shared_ptr<JobResult> RunJob(const std::string& path, const std::string& token, const std::string& qasm,
-                                      const std::uint32_t shots, const std::string& transpiler, const std::string& remark);
+                                      const std::uint32_t shots, const std::string& remark);
     std::shared_ptr<JobResult> CancelJob(const std::string& path, const std::string& token, const std::string& job_id);
     std::shared_ptr<JobResult> DeleteJob(const std::string& path, const std::string& token, const std::string& job_id);
 
 private:
     static const std::string kAuthorizationHeader;
     static const std::string kContentTypeHeader;
+    static const std::string kAcceptHeader;
 
-    std::string base_url_;
-    web::http::client::http_client http_client_;
+    std::string runtime_url_;
+    std::string transpile_url_;
+    web::http::client::http_client runtime_http_client_;
+    web::http::client::http_client transpile_http_client_;
 };
 
 }  // namespace rexrest

--- a/qcrpc/rest/src/ibmq_json.cpp
+++ b/qcrpc/rest/src/ibmq_json.cpp
@@ -2,9 +2,9 @@
 
 namespace rexrest {
 
-const std::string IBMQJsonParser::kQuasiDists = "quasi_dists";
-const std::string IBMQJsonParser::kMetadata = "metadata";
-const std::string IBMQJsonParser::kShots = "shots";
+const std::string IBMQJsonParser::kResults = "results";
+const std::string IBMQJsonParser::kData = "data";
+const std::string IBMQJsonParser::kSamples = "samples";
 
 std::shared_ptr<JsonResult> IBMQJsonParser::ScrapeResponse(const std::string& json_str,
                                                            std::uint32_t shots) {
@@ -13,21 +13,30 @@ std::shared_ptr<JsonResult> IBMQJsonParser::ScrapeResponse(const std::string& js
 }
 
 std::shared_ptr<JsonResult> IBMQJsonParser::Scrape() {
-    auto json = json::value::parse(this->json_str_);
-
-    auto metadata = json[IBMQJsonParser::kMetadata].as_array();
-    int shots = metadata[0][IBMQJsonParser::kShots].as_integer();
-
+    std::map<int, float> counts;
     std::shared_ptr<JsonResult> result = std::make_shared<JsonResult>();
+    
+    auto json = json::value::parse(this->json_str_);
+    auto data = json[kResults][0][kData].as_object();
 
-    auto quasiDists = json[IBMQJsonParser::kQuasiDists].as_array();
-    auto quasiDistObj = quasiDists[0].as_object();
-    for (auto quasiDist = quasiDistObj.cbegin(); quasiDist != quasiDistObj.cend(); ++quasiDist) {
-        int key = std::stoi(quasiDist->first, 0, 2);
-        float value = std::stof(std::to_string(quasiDist->second.as_double()));
+    // iterate over measured classical registers
+    for (auto const& it: data) {
+        json::value regData = it.second;
 
-        // Convert probability to number of observations
-        result->AddResult(key, value * shots);
+        // iterate over all samples (given as an array of hexadecimal values)
+        for (auto const& s: regData["samples"].as_array()) {
+            int key = std::strtol(s.as_string().c_str(), nullptr, 16);
+
+            if (counts.find(key) != counts.end()) {
+                counts[key] += 1;
+            } else {
+                counts[key] = 1;
+            }
+        }
+    }
+
+    for (auto const& it: counts) {
+        result->AddResult(it.first, it.second);
     }
 
     return result;

--- a/qcrpc/rest/src/ibmq_rest.cpp
+++ b/qcrpc/rest/src/ibmq_rest.cpp
@@ -8,18 +8,64 @@ namespace rexrest {
 const std::uint32_t IBMQClient::kPollingInterval = 900000;
 const std::uint32_t IBMQClient::kMaxPollingCount = 20;
 
+const std::string IBMQHttpClient::kTranspilerServiceURL = "https://cloud-transpiler.quantum.ibm.com";
+
+const std::string IBMQHttpClient::kBackend = "ibm_brisbane";
+const std::string IBMQHttpClient::kHub = "ibm-q";
+const std::string IBMQHttpClient::kGroup = "open";
+const std::string IBMQHttpClient::kProject = "main";
+
+const std::string IBMQHttpClient::kTranspilePath = "/transpile";
+const std::string IBMQHttpClient::kGetTranspilationResultsPath = "/transpile/";
 const std::string IBMQHttpClient::kListJobDetailsPath = "/jobs/";
 const std::string IBMQHttpClient::kListJobResultsPath = "/jobs/";
 const std::string IBMQHttpClient::kRunJobPath = "/jobs";
+
 const std::string IBMQHttpClient::kAuthorizationHeader = "Authorization";
 const std::string IBMQHttpClient::kContentTypeHeader = "Content-Type";
+const std::string IBMQHttpClient::kAcceptHeader = "Accept";
+
 const std::string IBMQHttpClient::kIDKey = "id";
+const std::string IBMQHttpClient::kTaskIDKey = "task_id";
 const std::string IBMQHttpClient::kStatusKey = "status";
+const std::string IBMQHttpClient::kStateKey = "state";
+const std::string IBMQHttpClient::kReasonKey = "reason";
+const std::string IBMQHttpClient::kResultKey = "result";
+const std::string IBMQHttpClient::kQASMKey = "qasm";
+
 const std::string IBMQHttpClient::kStatusCompletedValue = "Completed";
 const std::string IBMQHttpClient::kStatusFailedValue = "Failed";
 const std::string IBMQHttpClient::kStatusCancelledValue = "Cancelled";
-const std::string IBMQHttpClient::kStateKey = "state";
-const std::string IBMQHttpClient::kReasonKey = "reason";
+const std::string IBMQHttpClient::kStateSuccessValue = "SUCCESS";
+const std::string IBMQHttpClient::kStateFailureValue = "FAILURE";
+
+std::shared_ptr<JobResult> ParseResponse(http_response &res, const std::string &request_type = "",
+                                                const std::map<status_code, std::string> &status_messages = {}) {
+    if (res.status_code() == status_codes::OK) {
+        auto resString = res.extract_string().get();
+        return std::make_shared<JobResult>(res.status_code(), resString, "");
+    }
+
+    for (auto const& it: status_messages) {
+        if (res.status_code() == it.first) {
+            // for debug
+            if (request_type.length() > 0) {
+                std::cerr << request_type << " ";
+            }
+            std::cerr << "Error: " << res.status_code() << std::endl;
+
+            return std::make_shared<JobResult>(res.status_code(), "", it.second);
+        }
+    }
+
+    // for debug
+    if (request_type.length() > 0) {
+        std::cerr << request_type << " ";
+    }
+    std::cerr << "Error: " << res.status_code() << std::endl;
+
+    return std::make_shared<JobResult>(res.status_code(), "", "Unknown status code");
+}
 
 std::shared_ptr<JobResult> IBMQClient::Calculate(const std::string& base_url, const std::string& token,
                                                  const std::string& qasm, const std::uint32_t shots,
@@ -29,12 +75,51 @@ std::shared_ptr<JobResult> IBMQClient::Calculate(const std::string& base_url, co
 
     std::shared_ptr<IBMQHttpClient> client = IBMQHttpClient::CreateHttpClient(base_url);
 
-    auto transpilerStr = IBMQTranspilerToString(static_cast<IBMQTranspiler>(transpiler));
+    // submit transpile job
+    std::string transpiled_qasm = "";
+    std::shared_ptr<JobResult> transpileResult = client->TranspileCircuit(token, qasm, static_cast<IBMQTranspiler>(transpiler));
+    if (transpileResult->GetStatusCode() == status_codes::OK) {
+        auto transpileResJson = json::value::parse(transpileResult->GetJsonBody());
+        auto taskId = transpileResJson[IBMQHttpClient::kTaskIDKey].as_string();
+
+        // for debug
+        std::cerr << transpileResult->GetJsonBody().c_str() << std::endl;
+
+        for (std::uint32_t i = 0; i < max_polling_count; i++) {
+            std::shared_ptr<JobResult> transpilationResult = client->GetTranspilationResults(token, taskId);
+            if (transpilationResult->GetStatusCode() == status_codes::OK) {
+                auto resJson = json::value::parse(transpilationResult->GetJsonBody());
+                auto state = resJson[IBMQHttpClient::kStateKey].as_string();
+
+                // for debug
+                std::cerr << transpilationResult->GetJsonBody().c_str() << std::endl;
+
+                if (state == IBMQHttpClient::kStateSuccessValue) {
+                    transpiled_qasm = resJson[IBMQHttpClient::kResultKey][0][IBMQHttpClient::kQASMKey].as_string();
+                    break;
+                } else if (state == IBMQHttpClient::kStateFailureValue) {
+                    // for debug
+                    std::cerr << "Transpile Failed: " << resJson[IBMQHttpClient::kResultKey].as_string().c_str() << std::endl;
+                    return std::make_shared<JobResult>(0, "", resJson[IBMQHttpClient::kResultKey].as_string());
+                } else {
+                    // for debug
+                    std::cerr << "Transpile Wait: " << i << std::endl;
+
+                    std::this_thread::sleep_for(std::chrono::milliseconds(polling_interval));
+                    continue;
+                }
+            } else {
+                return transpilationResult;
+            }
+        }
+    } else {
+        return transpileResult;
+    }
 
     // submit job
-    std::shared_ptr<JobResult> runResult = client->RunJob(IBMQHttpClient::kRunJobPath, token, qasm, shots, transpilerStr, remark);
+    std::shared_ptr<JobResult> runResult = client->RunJob(IBMQHttpClient::kRunJobPath, token, transpiled_qasm, shots, remark);
 
-    if (runResult->GetStatusCode() == web::http::status_codes::OK) {
+    if (runResult->GetStatusCode() == status_codes::OK) {
         auto runResJson = json::value::parse(runResult->GetJsonBody());
         auto jobId = runResJson[IBMQHttpClient::kIDKey].as_string();
 
@@ -43,7 +128,7 @@ std::shared_ptr<JobResult> IBMQClient::Calculate(const std::string& base_url, co
 
         for (std::uint32_t i = 0; i < max_polling_count; i++) {
             std::shared_ptr<JobResult> detailsResult = client->ListJobDetails(IBMQHttpClient::kListJobDetailsPath, token, jobId);
-            if (detailsResult->GetStatusCode() == web::http::status_codes::OK) {
+            if (detailsResult->GetStatusCode() == status_codes::OK) {
                 auto getResJson = json::value::parse(detailsResult->GetJsonBody());
                 auto status = getResJson[IBMQHttpClient::kStatusKey].as_string();
 
@@ -79,13 +164,65 @@ std::shared_ptr<JobResult> IBMQClient::Calculate(const std::string& base_url, co
     }
 }
 
-std::shared_ptr<JobResult> IBMQHttpClient::ListJobDetails(const std::string& path,
-                                                          const std::string& token,
-                                                          const std::string& job_id) {
+std::shared_ptr<JobResult> IBMQHttpClient::TranspileCircuit(const std::string &token, const std::string &qasm,
+                                                            const IBMQTranspiler transpiler)
+{
+    // create path
+    uri_builder builder(this->transpile_url_);
+    builder.set_path(kTranspilePath);
+    builder.append_query("backend=" + kBackend);
+    builder.append_query("optimization_level=3");
+    builder.append_query("ai=" + IBMQTranspilerUseAI(transpiler));
+
+    // create request
+    http_request req(methods::POST);
+    req.set_request_uri(builder.to_string());
+    req.headers().add(kAuthorizationHeader, "Bearer " + token);
+    req.headers().add(kContentTypeHeader, "application/json");
+    req.headers().add(kAcceptHeader, "application/json");
+
+    // create JSON
+    // https://docs.quantum.ibm.com/api/qiskit-transpiler-service-rest/tags/transpiler-methods#tags__transpiler-methods__operations__transpile_transpile_post
+    json::value reqJson;
+
+    json::value circuitsJson;
+    circuitsJson[0] = json::value::string(qasm);
+
+    reqJson["qasm_circuits"] = circuitsJson;
+
+    req.set_body(reqJson.serialize());
+
+    // send request
+    http_response res = this->transpile_http_client_.request(req).get();
+    return ParseResponse(res, "Transpile", {{status_codes::UnprocessableEntity, "Validation Error"}});
+}
+
+std::shared_ptr<JobResult> IBMQHttpClient::GetTranspilationResults(const std::string &token, const std::string &task_id)
+{
+    // create path
+    uri_builder builder(this->transpile_url_);
+    builder.set_path(kTranspilePath);
+    builder.append_path(task_id);
+
+    // create request
+    http_request req(methods::GET);
+    req.set_request_uri(builder.to_string());
+    req.headers().add(kAuthorizationHeader, "Bearer " + token);
+    req.headers().add(kAcceptHeader, "application/json");
+
+    // send request
+    http_response res = this->transpile_http_client_.request(req).get();
+    return ParseResponse(res, "GetTranspilationResults", {{status_codes::UnprocessableEntity, "Validation Error"}});
+}
+
+std::shared_ptr<JobResult> IBMQHttpClient::ListJobDetails(const std::string &path,
+                                                          const std::string &token,
+                                                          const std::string &job_id)
+{
     // TODO: Add parameter checks
 
     // create path
-    uri_builder builder(this->base_url_);
+    uri_builder builder(this->runtime_url_);
     builder.set_path(path);
     builder.append_path(job_id);
 
@@ -93,35 +230,15 @@ std::shared_ptr<JobResult> IBMQHttpClient::ListJobDetails(const std::string& pat
     http_request req(methods::GET);
     req.set_request_uri(builder.to_string());
     req.headers().add(kAuthorizationHeader, "Bearer " + token);
+    req.headers().add(kAcceptHeader, "application/json");
 
-    http_response res = this->http_client_.request(req).get();
-    switch (res.status_code()) {
-        case web::http::status_codes::OK: {
-            auto resString = res.extract_string().get();
-            return std::make_shared<JobResult>(res.status_code(), resString, "");
-        }
-
-        case web::http::status_codes::Unauthorized: {
-            std::cerr << "ListJobDetails Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Unauthorized");
-        }
-        case web::http::status_codes::Forbidden: {
-            std::cerr << "ListJobDetails Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Forbidden");
-        }
-        case web::http::status_codes::NotFound: {
-            std::cerr << "ListJobDetails Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Not Found");
-        }
-        case web::http::status_codes::InternalError: {
-            std::cerr << "ListJobDetails Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Internal Error");
-        }
-        default: {
-            std::cerr << "ListJobDetails Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Unknown status code");
-        }
-    }
+    http_response res = this->runtime_http_client_.request(req).get();
+    return ParseResponse(res, "ListJobDetails", {
+                                                    {status_codes::Unauthorized, "Unauthorized"},
+                                                    {status_codes::Forbidden, "Forbidden"},
+                                                    {status_codes::NotFound, "Not Found"},
+                                                    {status_codes::InternalError, "Internal Error"},
+                                                });
 }
 
 std::shared_ptr<JobResult> IBMQHttpClient::ListJobResults(const std::string& path,
@@ -130,7 +247,7 @@ std::shared_ptr<JobResult> IBMQHttpClient::ListJobResults(const std::string& pat
     // TODO: Add parameter checks
 
     // create path
-    uri_builder builder(this->base_url_);
+    uri_builder builder(this->runtime_url_);
     builder.set_path(path);
     builder.append_path(job_id);
     builder.append_path("results");
@@ -139,51 +256,27 @@ std::shared_ptr<JobResult> IBMQHttpClient::ListJobResults(const std::string& pat
     http_request req(methods::GET);
     req.set_request_uri(builder.to_string());
     req.headers().add(kAuthorizationHeader, "Bearer " + token);
+    req.headers().add(kAcceptHeader, "application/json");
 
-    http_response res = this->http_client_.request(req).get();
-    switch (res.status_code()) {
-        case web::http::status_codes::OK: {
-            auto resString = res.extract_string().get();
-            return std::make_shared<JobResult>(res.status_code(), resString, "");
-        }
-        case web::http::status_codes::NoContent: {
-            std::cerr << "ListJobResults Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "No Content");
-        }
-        case web::http::status_codes::BadRequest: {
-            std::cerr << "ListJobResults Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Bad Request");
-        }
-        case web::http::status_codes::Unauthorized: {
-            std::cerr << "ListJobDetails Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Unauthorized");
-        }
-        case web::http::status_codes::Forbidden: {
-            std::cerr << "ListJobDetails Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Forbidden");
-        }
-        case web::http::status_codes::NotFound: {
-            std::cerr << "ListJobDetails Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Not Found");
-        }
-        case web::http::status_codes::InternalError: {
-            std::cerr << "ListJobDetails Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Internal Error");
-        }
-        default: {
-            std::cerr << "ListJobDetails Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Unknown status code");
-        }
-    }
+    // send request
+    http_response res = this->runtime_http_client_.request(req).get();
+    return ParseResponse(res, "ListJobResults", {
+                                                    {status_codes::NoContent, "No Content"},
+                                                    {status_codes::BadRequest, "Bad Request"},
+                                                    {status_codes::Unauthorized, "Unauthorized"},
+                                                    {status_codes::Forbidden, "Forbidden"},
+                                                    {status_codes::NotFound, "Not Found"},
+                                                    {status_codes::InternalError, "Internal Error"},
+                                                });
 }
 
 std::shared_ptr<JobResult> IBMQHttpClient::RunJob(const std::string& path, const std::string& token,
                                                   const std::string& qasm, const std::uint32_t shots,
-                                                  const std::string& transpiler, const std::string& remark) {
+                                                  const std::string& remark) {
     // TODO: Add parameter checks
 
     // create path
-    uri_builder builder(this->base_url_);
+    uri_builder builder(this->runtime_url_);
     builder.set_path(path);
 
     // create request
@@ -191,58 +284,38 @@ std::shared_ptr<JobResult> IBMQHttpClient::RunJob(const std::string& path, const
     req.set_request_uri(builder.to_string());
     req.headers().add(kAuthorizationHeader, "Bearer " + token);
     req.headers().add(kContentTypeHeader, "application/json");
+    req.headers().add(kAcceptHeader, "application/json");
 
     // create JSON
     //
     // https://docs.quantum.ibm.com/api/runtime/tags/jobs#tags__jobs__operations__CreateJobController_createJob
     json::value reqJson;
     reqJson["program_id"] = json::value::string("sampler");
-    reqJson["backend"] = json::value::string("ibmq_qasm_simulator"); // actual machine settings: ibm_brisbane
-    reqJson["hub"] = json::value::string("ibm-q");    // JSON elements not required for IBM Cloud services
-    reqJson["group"] = json::value::string("open");   // JSON elements not required for IBM Cloud services
-    reqJson["project"] = json::value::string("main"); // JSON elements not required for IBM Cloud services
+    reqJson["backend"] = json::value::string(kBackend); // actual machine settings: ibm_brisbane
+    reqJson["hub"] = json::value::string(kHub);    // JSON elements not required for IBM Cloud services
+    reqJson["group"] = json::value::string(kGroup);   // JSON elements not required for IBM Cloud services
+    reqJson["project"] = json::value::string(kProject); // JSON elements not required for IBM Cloud services
+
+    json::value pubsJson;
+    pubsJson[0][0] = json::value::string(qasm);
 
     json::value paramsJson;
-    paramsJson[0] = json::value::string(qasm);
+    paramsJson["pubs"] = pubsJson;
+    paramsJson["shots"] = json::value::number(shots);
+    paramsJson["version"] = json::value::number(2);
 
-    json::value circuitsJson;
-    circuitsJson["circuits"] = paramsJson;
-
-    reqJson["params"] = circuitsJson;
+    reqJson["params"] = paramsJson;
 
     req.set_body(reqJson.serialize());
 
-    http_response res = this->http_client_.request(req).get();
-    switch (res.status_code()) {
-        case web::http::status_codes::OK: {
-            auto resString = res.extract_string().get();
-            return std::make_shared<JobResult>(res.status_code(), resString, "");
-        }
-        case web::http::status_codes::BadRequest: {
-            std::cerr << "RunJob Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Bad Request");
-        }
-        case web::http::status_codes::Unauthorized: {
-            std::cerr << "RunJob Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Unauthorized");
-        }
-        case web::http::status_codes::NotFound: {
-            std::cerr << "RunJob Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Not Found");
-        }
-        case web::http::status_codes::Conflict: {
-            std::cerr << "RunJob Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Conflict");
-        }
-        case web::http::status_codes::InternalError: {
-            std::cerr << "RunJob Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Internal Error");
-        }
-        default: {
-            std::cerr << "RunJob Error: " << res.status_code() << std::endl;
-            return std::make_shared<JobResult>(res.status_code(), "", "Unknown status code");
-        }
-    }
+    http_response res = this->runtime_http_client_.request(req).get();
+    return ParseResponse(res, "RunJob", {
+                                            {status_codes::BadRequest, "Bad Request"},
+                                            {status_codes::Unauthorized, "Unauthorized"},
+                                            {status_codes::NotFound, "Not Found"},
+                                            {status_codes::Conflict, "Conflict"},
+                                            {status_codes::InternalError, "Internal Error"},
+                                        });
 }
 
 std::shared_ptr<JobResult> IBMQHttpClient::CancelJob(const std::string& path, const std::string& token,


### PR DESCRIPTION
Update the QCRPC IBM-Q REST C++ implementation to work with the current version of the API.

Changes:

- Add transpilation step using IBM's cloud transpiler service.
- Update job requests schemas.
- Update JSON results parsing.

Remark: simulator backends have been remove from IBM Quantum services, only physical QPUs are available (default backend changed to `ibm_brisbane` to reflect this change)